### PR TITLE
Update OZ contracts version to v5.5.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/foundry-rs/forge-std
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+	url = https://github.com/openzeppelin/openzeppelin-contracts

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,6 @@
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
 ds-test/=lib/forge-std/lib/ds-test/src/
+erc4626-tests/=lib/openzeppelin-contracts/lib/erc4626-tests/
 forge-std/=lib/forge-std/src/
-openzeppelin-contracts/=lib/openzeppelin-contracts/contracts/
+halmos-cheatcodes/=lib/openzeppelin-contracts/lib/halmos-cheatcodes/src/
 ercx/=src/

--- a/src/ERC1155/ERC1155Abstract.sol
+++ b/src/ERC1155/ERC1155Abstract.sol
@@ -2,9 +2,9 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import "../ERCAbstract.sol";
-import {IERC1155} from "openzeppelin-contracts/token/ERC1155/IERC1155.sol";
-import {IERC1155Receiver} from "openzeppelin-contracts/token/ERC1155/IERC1155Receiver.sol";
-import {ERC1155ReceiverMock} from "openzeppelin-contracts/mocks/token/ERC1155ReceiverMock.sol";
+import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {IERC1155Receiver} from "@openzeppelin/contracts/token/ERC1155/IERC1155Receiver.sol";
+import {ERC1155ReceiverMock} from "@openzeppelin/contracts/mocks/token/ERC1155ReceiverMock.sol";
 
 /// @notice Abstract contract that defines internal functions that are used in ERC1155 test suite
 abstract contract ERC1155Abstract is ERCAbstract {
@@ -163,12 +163,13 @@ abstract contract ERC1155Abstract is ERCAbstract {
     /// Otherwise, include an additional "bytes4 _otherRecRetVal" input for the test function and 
     /// let the fuzz mechanism take care of the random bytes4 return value.
     /// Same goes for _correctBatRetVal and _otherBatRetVal.
-    /// @dev If _recReverts set to true, then the contract receiver will always revert when receiving tokens.
-    /// Same goes for _batReverts.
+    /// @dev If _recReverts OR _batReverts is set to true, then the contract receiver will revert.
+    /// Note: In v5, both single and batch transfers use the same revert behavior.
     function _setUpReceiverContract(bool _correctRecRetVal, bytes4 _otherRecRetVal, bool _recReverts, bool _correctBatRetVal, bytes4 _otherBatRetVal, bool _batReverts)
     internal returns (IERC1155Receiver) {
         bytes4 _recRetval;
         bytes4 _batRetval;
+        
         // if _correctRecRecVal is set to true, the receiver contract will return the correct
         // bytes4 return value, which is `onERC1155Received(address,address,uint256,uint256,bytes)`
         if (_correctRecRetVal) {
@@ -180,6 +181,7 @@ abstract contract ERC1155Abstract is ERCAbstract {
             vm.assume(_otherRecRetVal != IERC1155Receiver.onERC1155Received.selector);
             _recRetval = _otherRecRetVal;
         }
+        
         // if _correctBatRecVal is set to true, the receiver contract will return the correct
         // bytes4 return value, which is `onERC1155BatchReceived(address,address,uint256[],uint256[],bytes)`
         if (_correctBatRetVal) {
@@ -190,8 +192,16 @@ abstract contract ERC1155Abstract is ERCAbstract {
             vm.assume(_otherBatRetVal != IERC1155Receiver.onERC1155BatchReceived.selector);
             _batRetval = _otherBatRetVal;
         }
-        // Set up the receiver contract accordingly and return it as output
-        ERC1155ReceiverMock receiverContract = new ERC1155ReceiverMock(_recRetval, _recReverts, _batRetval, _batReverts);
+        
+        // Determine the revert type based on the input flags
+        ERC1155ReceiverMock.RevertType revertType;
+        if (_recReverts || _batReverts) {
+            revertType = ERC1155ReceiverMock.RevertType.RevertWithMessage;
+        } else {
+            revertType = ERC1155ReceiverMock.RevertType.None;
+        }
+        
+        ERC1155ReceiverMock receiverContract = new ERC1155ReceiverMock(_recRetval, _batRetval, revertType);
         return IERC1155Receiver(address(receiverContract));
     }
 

--- a/src/ERC20/ERC20Abstract.sol
+++ b/src/ERC20/ERC20Abstract.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.6.2 <0.9.0;
 
-import "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../ERCAbstract.sol";
 
 /// @notice Abstract contract that defines internal functions that are used in ERC20 test suite

--- a/src/ERC20/ERC20MetadataTest.sol
+++ b/src/ERC20/ERC20MetadataTest.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import "forge-std/Test.sol";
-import "openzeppelin-contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 /// @dev This test contract extracts metadata from an ERC20 token. 
 /// @dev The information is contained in the JSON-output.

--- a/src/ERC4626/ERC4626Abstract.sol
+++ b/src/ERC4626/ERC4626Abstract.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import "../ERCAbstract.sol";
-import "openzeppelin-contracts/interfaces/IERC4626.sol";
+import "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 /// @notice Abstract contract that defines internal functions that are used in ERC4626 test suite
 abstract contract ERC4626Abstract is ERCAbstract {

--- a/src/mocks/ERC1155Mock.sol
+++ b/src/mocks/ERC1155Mock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC1155} from "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+
+contract ERC1155Mock is ERC1155 {
+    constructor(string memory uri) ERC1155(uri) {}
+
+    function mint(address to, uint256 id, uint256 amount) external {
+        _mint(to, id, amount, "");
+    }
+
+    function mintBatch(address to, uint256[] memory ids, uint256[] memory amounts) external {
+        _mintBatch(to, ids, amounts, "");
+    }
+
+    function burn(address from, uint256 id, uint256 amount) external {
+        _burn(from, id, amount);
+    }
+
+    function burnBatch(address from, uint256[] memory ids, uint256[] memory amounts) external {
+        _burnBatch(from, ids, amounts);
+    }
+
+    function setURI(string memory newuri) external {
+        _setURI(newuri);
+    }
+}

--- a/src/mocks/ERC20Mock.sol
+++ b/src/mocks/ERC20Mock.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20Mock is ERC20 {
+    constructor() ERC20("ERC20Mock", "E20M") {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+}

--- a/src/mocks/ERC4626Mock.sol
+++ b/src/mocks/ERC4626Mock.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {IERC20, ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+
+contract ERC4626Mock is ERC4626 {
+    constructor(address underlying) ERC20("ERC4626Mock", "E4626M") ERC4626(IERC20(underlying)) {}
+
+    function mint(address account, uint256 amount) external {
+        _mint(account, amount);
+    }
+
+    function burn(address account, uint256 amount) external {
+        _burn(account, amount);
+    }
+}

--- a/src/mocks/ERC721IncorrectReceiver.sol
+++ b/src/mocks/ERC721IncorrectReceiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "openzeppelin-contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 contract ERC721IncorrectReceiver is IERC721Receiver {
 

--- a/src/mocks/ERC721Receiver.sol
+++ b/src/mocks/ERC721Receiver.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "openzeppelin-contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
 contract ERC721Receiver is IERC721Receiver {
 

--- a/test/golden/ERC1155MockTest.t.sol
+++ b/test/golden/ERC1155MockTest.t.sol
@@ -2,12 +2,12 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import "ercx/ERC1155/ERC1155Test.sol";
-import {ERC1155} from "openzeppelin-contracts/token/ERC1155/ERC1155.sol";
+import {ERC1155Mock} from "src/mocks/ERC1155Mock.sol";
 
 contract ERC1155MockTest is ERC1155Test {
 
     function setUp() public {
-        ERC1155 token = new ERC1155("ERC1155Mock");
+        ERC1155Mock token = new ERC1155Mock("ERC1155Mock");
         ERC1155Test.init(address(token));
     }
 

--- a/test/golden/ERC20MockTest.t.sol
+++ b/test/golden/ERC20MockTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import "ercx/ERC20/Light/ERC20Test.sol";
-import {ERC20Mock} from "openzeppelin-contracts/mocks/ERC20Mock.sol";
+import {ERC20Mock} from "src/mocks/ERC20Mock.sol";
 
 contract ERC20MockTest is ERC20Test {
 

--- a/test/golden/ERC4626MockTest.t.sol
+++ b/test/golden/ERC4626MockTest.t.sol
@@ -2,8 +2,8 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import "ercx/ERC4626/Light/ERC4626Test.sol";
-import {ERC20Mock} from "openzeppelin-contracts/mocks/ERC20Mock.sol";
-import {ERC4626Mock} from "openzeppelin-contracts/mocks/ERC4626Mock.sol";
+import {ERC20Mock} from "src/mocks/ERC20Mock.sol";
+import {ERC4626Mock} from "src/mocks/ERC4626Mock.sol";
 
 contract ERC4626MockTest is ERC4626Test {
 


### PR DESCRIPTION
This PR updates the version of `openzeppelin-contracts` to v5.5.0 to support the `Math.saturatingSub` function that can be used to introduce fuzzer input bounds into some of the tests.